### PR TITLE
Pyidl console script improvements

### DIFF
--- a/pyopendds/dev/itl2py/PythonOutput.py
+++ b/pyopendds/dev/itl2py/PythonOutput.py
@@ -54,7 +54,10 @@ class PythonOutput(Output):
         submodule.visit_root_module(module)
 
     def is_local_type(self, type_node):
-        return type_node in self.module.types.values()
+        if isinstance(type_node, (SequenceType, ArrayType)):
+            return type_node.base_type in self.module.types.values()
+        else:
+            return type_node in self.module.types.values()
 
     def get_python_type_string(self, field_type):
         if isinstance(field_type, PrimitiveType):

--- a/pyopendds/dev/pyidl/__main__.py
+++ b/pyopendds/dev/pyidl/__main__.py
@@ -69,23 +69,25 @@ def mk_tmp_package_proj(args: argparse.Namespace):
                 gen_cmakelist(target_name=args.package_name,
                               pyopendds_ldir=args.pyopendds_ld,
                               idl_files=args.input_files,
-                              include_dirs=args.include_paths))
+                              include_dirs=args.include_paths,
+                              venv_path=os.environ['VIRTUAL_ENV']))
 
     # Create setup.py
     mk_tmp_file(f"{args.output_dir}/setup.py",
                 gen_setup(target_name=args.package_name))
 
     # Create a the empty __init__.py to indicate the project is a package
-    subprocess.run(['mkdir', args.package_name],
-                   cwd=args.output_dir)
-    mk_tmp_file(f"{args.output_dir}/{args.package_name}/__init__.py", "")
-
-    # Install a dummy python package [package_name]
-    print(f"Init dummy '{args.package_name}' Python package...")
-    subprocess.run(['python3', 'setup.py', 'install'],
-                   cwd=args.output_dir)
+    # subprocess.run(['mkdir', args.package_name],
+    #                cwd=args.output_dir)
+    # mk_tmp_file(f"{args.output_dir}/{args.package_name}/__init__.py", "")
+    #
+    # # Install a dummy python package [package_name]
+    # print(f"Init dummy '{args.package_name}' Python package...")
+    # subprocess.run(['python3', 'setup.py', 'install'],
+    #                cwd=args.output_dir)
 
     # Run cmake to prepare the python to cpp bindings
+    subprocess.run(['mkdir', 'build'], cwd=args.output_dir)
     subprocess.run(['cmake', '..'], cwd=f"{args.output_dir}/build")
     subprocess.run(['make'], cwd=f"{args.output_dir}/build")
 

--- a/pyopendds/dev/pyidl/__main__.py
+++ b/pyopendds/dev/pyidl/__main__.py
@@ -173,17 +173,24 @@ def run():
             sys.exit(1)
     args.__setattr__('output_dir', os.path.realpath(args.output_dir))
 
+    # Create the output directory if it does not exist
+    if not os.path.exists(args.output_dir):
+        subprocess.run(['mkdir', '-p', args.output_dir])
+
     # Check pyopendds include path (which is required in further CMake process)
     # Order of discovery is:
     #     1- Folder name or path given as input
     #     2- Environment variable named PYOPENDDS_LD
     #     1- Direct reference to include directory installed in pyopendds .egg archive (always successes)
+    include_subpath = '/pyopendds/dev/include'
     if not args.pyopendds_ld:
         env_pyopendds_ld = os.getenv('PYOPENDDS_LD')
         if not env_pyopendds_ld:
             args.__setattr__('pyopendds_ld', extract_include_path_from_egg(args.output_dir))
         else:
-            args.__setattr__('pyopendds_ld', env_pyopendds_ld)
+            args.__setattr__('pyopendds_ld', f'{env_pyopendds_ld}{include_subpath}')
+    else:
+        args.__setattr__('pyopendds_ld', f'{args.pyopendds_ld}{include_subpath}')
     args.__setattr__('pyopendds_ld', os.path.realpath(args.pyopendds_ld))
 
     # Parse package name. If no name is given, the basename of the first .idl file will be taken

--- a/pyopendds/dev/pyidl/gencmakefile.py
+++ b/pyopendds/dev/pyidl/gencmakefile.py
@@ -26,12 +26,6 @@ def gen_cmakelist(target_name: str,
         statement_5 += f'    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/pyidl/{target_name}"\n'
         statement_5 += ')'
 
-    statement_5 = ""
-    if venv_path:
-        statement_5 += f'set_target_properties({target_name}_idl PROPERTIES\n'
-        statement_5 += f'    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/{target_name}"\n'
-        statement_5 += ')'
-
     return f"""
 cmake_minimum_required(VERSION 3.10)
 

--- a/pyopendds/dev/pyidl/gencmakefile.py
+++ b/pyopendds/dev/pyidl/gencmakefile.py
@@ -2,7 +2,8 @@
 def gen_cmakelist(target_name: str,
                   pyopendds_ldir: str,
                   idl_files: list,
-                  include_dirs: list):
+                  include_dirs: list,
+                  venv_path: str = ""):
     statement_0 = ""
     for idx, include_dir in enumerate(include_dirs):
         statement_0 += f'set(inc_dir_{idx} "{include_dir}")\n'
@@ -20,6 +21,12 @@ def gen_cmakelist(target_name: str,
     for idx, _ in enumerate(include_dirs):
         statement_4 += f' -I${{inc_dir_{idx}}}'
 
+    statement_5 = ""
+    if venv_path:
+        statement_5 += f'set_target_properties({target_name}_idl PROPERTIES\n'
+        statement_5 += f'    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/{target_name}"\n'
+        statement_5 += ')'
+
     return f"""
 cmake_minimum_required(VERSION 3.10)
 
@@ -31,6 +38,9 @@ find_package(OpenDDS REQUIRED)
 add_library({target_name}_idl SHARED)
 target_include_directories({target_name}_idl PUBLIC "${{CMAKE_CURRENT_SOURCE_DIR}}/build")
 {statement_1}
+set_target_properties({target_name}_idl PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/{target_name}"
+)
 if(${{CPP11_IDL}})
     set(opendds_idl_mapping_option "-Lc++11")
 endif()

--- a/pyopendds/dev/pyidl/gencmakefile.py
+++ b/pyopendds/dev/pyidl/gencmakefile.py
@@ -10,16 +10,21 @@ def gen_cmakelist(target_name: str,
 
     statement_1 = ""
     for idx, _ in enumerate(include_dirs):
-        statement_1 += f'target_include_directories({target_name}_idl PUBLIC "${{inc_dir_{idx}}}")\n'
+        statement_1 += f'\ntarget_include_directories({target_name}_idl PUBLIC "${{inc_dir_{idx}}}")'
 
     statement_3 = ""
     for idl_file in idl_files:
-        statement_3 += f' {idl_file}'
-    statement_3 = f'PUBLIC{statement_3}'
+        statement_3 += f'\n    {idl_file}'
 
     statement_4 = ""
     for idx, _ in enumerate(include_dirs):
-        statement_4 += f' -I${{inc_dir_{idx}}}'
+        statement_4 += f'\n    -I${{inc_dir_{idx}}}'
+
+    statement_5 = ""
+    if venv_path:
+        statement_5 += f'set_target_properties({target_name}_idl PROPERTIES\n'
+        statement_5 += f'    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/pyidl/{target_name}"\n'
+        statement_5 += ')'
 
     statement_5 = ""
     if venv_path:
@@ -36,17 +41,15 @@ list(APPEND CMAKE_MODULE_PATH "$ENV{{DDS_ROOT}}/cmake")
 find_package(OpenDDS REQUIRED)
 {statement_0}
 add_library({target_name}_idl SHARED)
-target_include_directories({target_name}_idl PUBLIC "${{CMAKE_CURRENT_SOURCE_DIR}}/build")
-{statement_1}
-set_target_properties({target_name}_idl PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "{venv_path}/lib/{target_name}"
-)
+target_include_directories({target_name}_idl PUBLIC "${{CMAKE_CURRENT_SOURCE_DIR}}/build"){statement_1}
+{statement_5}
+
 if(${{CPP11_IDL}})
     set(opendds_idl_mapping_option "-Lc++11")
 endif()
 
 set(OPENDDS_FILENAME_ONLY_INCLUDES ON)
-OPENDDS_TARGET_SOURCES({target_name}_idl {statement_3}
+OPENDDS_TARGET_SOURCES({target_name}_idl PUBLIC{statement_3}
     OPENDDS_IDL_OPTIONS "-Gitl" "${{opendds_idl_mapping_option}}"{statement_4}
 )
 
@@ -56,5 +59,8 @@ export(
     FILE "${{CMAKE_CURRENT_BINARY_DIR}}/{target_name}_idlConfig.cmake"
 )
 
-target_include_directories({target_name}_idl PUBLIC "{pyopendds_ldir}")
+target_include_directories({target_name}_idl PUBLIC
+    "{pyopendds_ldir}"
+)
+
 """


### PR DESCRIPTION
Part of the pyidl feature was injected with swolferDF's pull request. This PR contains the following fixes:

- a shared library (generated before itl2py command) is sometimes needed by the final package. 
This library is now copied into the venv, but not yet part of the final package data. Remember to delete venv/lib/pyidl/packagename folder when uninstalling with pip uninstall.

- output directory was not created when the command was used with -o, now the output directory (and all non-existing parent folders) are created.