### PR TITLE
Split packages + path review

### DIFF
--- a/pyopendds/dev/itl2py/__main__.py
+++ b/pyopendds/dev/itl2py/__main__.py
@@ -24,6 +24,10 @@ Name of the Python package to create. If there is only one ITL file, then by
 default this will be \'py\' and the name of the ITL file with the .itl
 extension (my_types.itl -> pymy_types). If there are are multiple ITL files,
 then this option becomes required.''')
+    argparser.add_argument('-v', '--package-version',
+                           type=str,
+                           default='0.0.1',
+                           help='Version of the Python package to create.')
     argparser.add_argument('--native-package-name',
         type=str,
         help='''\

--- a/pyopendds/dev/itl2py/templates/setup.py
+++ b/pyopendds/dev/itl2py/templates/setup.py
@@ -6,6 +6,7 @@ from pyopendds.dev.cmake import \
 
 setup(
     name='{{ package_name }}',
+    version='{{ package_version }}',
     packages=find_packages(),
     ext_modules=[CMakeWrapperExtension(
         name='{{ native_package_name }}',

--- a/setup-dev.py
+++ b/setup-dev.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_namespace_packages
+
+setup(
+    name='pyopendds.dev',
+    packages=['pyopendds.dev', 'pyopendds.dev.pyidl', 'pyopendds.dev.itl2py'],
+    package_data={
+        'pyopendds.dev': [
+            'include/pyopendds/*',
+        ],
+        'pyopendds.dev.itl2py': [
+            'templates/*',
+        ],
+    },
+    entry_points={
+        'console_scripts': [
+            'itl2py=pyopendds.dev.itl2py.__main__:main',
+            'pyidl=pyopendds.dev.pyidl.__main__:run',
+        ],
+    },
+    install_requires=[
+        'Jinja2',
+    ],
+)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-name = pyopendds
 version = 0.1.0
 author = Fred Hornsey
 author_email = hornseyf@objectcomputing.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.1.0
+version = 0.2.0
 author = Fred Hornsey
 author_email = hornseyf@objectcomputing.com
 home_page = https://github.com/oci-labs/pyopendds

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,10 @@
 from pathlib import Path
-from setuptools import setup, find_packages
+from setuptools import setup
 from pyopendds.dev.cmake import CMakeWrapperExtension, CMakeWrapperBuild
-import distutils.command.sdist
-import sys
 
-
-ext_package = {'pyopendds': ['ext/*']}
 setup(
-    packages=find_packages(),
+    name='pyopendds',
+    packages=['pyopendds'],
     ext_modules=[CMakeWrapperExtension(
         name='_pyopendds',
         cmakelists_dir='pyopendds/ext',
@@ -17,24 +14,4 @@ setup(
         },
     )],
     cmdclass={'build_ext': CMakeWrapperBuild},
-    entry_points={
-        'console_scripts': [
-            'itl2py=pyopendds.dev.itl2py.__main__:main',
-            'pyidl=pyopendds.dev.pyidl.__main__:run',
-        ],
-    },
-    package_data={
-        'pyopendds':['ext/*'] if 'sdist' in sys.argv else [],
-        'pyopendds':['ext/*'] if 'bdist_rpm' in sys.argv else [],
-        'pyopendds.dev': [
-            'include/pyopendds/*',
-        ],
-        'pyopendds.dev.itl2py': [
-            'templates/*', 
-        ],
-
-    },
-    install_requires=[
-        'Jinja2'
-    ],
 )


### PR DESCRIPTION
* pyopendds is only the libopendds binding
* pyopendds.dev is the IDL to python package.
* pyidl now generate a wheel file in the *output_dir/dist*.
  By default, the package is not installed.
* add --package-version for pyidl, this version is reported in name of the package generated.
* add --force-install to pyidl. This option will install the package in the system.

* use os.path instead of strings (OS compatibility)
* create additional *build* level to store the CMakefile in it