### PR TITLE
Bugfix - Cannot find Byte in pyopendds.util

### DIFF
--- a/pyopendds/dev/include/pyopendds/basictype.hpp
+++ b/pyopendds/dev/include/pyopendds/basictype.hpp
@@ -43,8 +43,6 @@ public:
 
 PyObject* pyopendds_mod_str = NULL;
 PyObject* pyopendds_mod = NULL;
-PyObject* pyopendds_byte_func = NULL;
-PyObject* pyopendds_ubyte_func = NULL;
 
 template<typename T>
 class IntegerType {
@@ -114,20 +112,6 @@ private:
             pyopendds_mod = PyImport_Import(pyopendds_mod_str);
             if (!pyopendds_mod)
                 throw Exception("Cannot import \"pyopendds.util\"", PyExc_ImportError);
-        }
-
-        // Getting a reference to the Byte object initializer
-        if (!pyopendds_byte_func) {
-            pyopendds_byte_func = PyObject_GetAttrString(pyopendds_mod, (char*)"Byte");
-            if (!pyopendds_byte_func)
-                throw Exception("Cannot find \"Byte()\" in \"pyopendds.util\"", PyExc_NameError);
-        }
-
-        // Getting a reference to the UByte object initializer
-        if (!pyopendds_ubyte_func) {
-            pyopendds_ubyte_func = PyObject_GetAttrString(pyopendds_mod, (char*)"UByte");
-            if (!pyopendds_ubyte_func)
-                throw Exception("Cannot find \"UByte()\" in \"pyopendds.util\"", PyExc_NameError);
         }
 
         return true;

--- a/pyopendds/dev/include/pyopendds/basictype.hpp
+++ b/pyopendds/dev/include/pyopendds/basictype.hpp
@@ -61,13 +61,13 @@ public:
             if (sizeof(cpp) > sizeof(long)) {
                 py = PyLong_FromLongLong(cpp);
             } else {
-                    py = PyLong_FromLong(cpp);
+                py = PyLong_FromLong(cpp);
             }
         } else {
             if (sizeof(cpp) > sizeof(long)) {
                 py = PyLong_FromUnsignedLongLong(cpp);
             } else {
-                    py = PyLong_FromUnsignedLong(cpp);
+                py = PyLong_FromUnsignedLong(cpp);
             }
         }
     }
@@ -79,18 +79,18 @@ public:
             if (sizeof(T) == sizeof(long long)) {
                 value = PyLong_AsLongLong(py);
             } else {
-                    value = PyLong_AsLong(py);
+                value = PyLong_AsLong(py);
             }
         } else {
             if (sizeof(T) == sizeof(long long)) {
                 value = PyLong_AsUnsignedLongLong(py);
             } else {
-                    value = PyLong_AsUnsignedLong(py);
+                value = PyLong_AsUnsignedLong(py);
             }
         }
-        if (value < limits::lowest() || value > limits::max()) {
+        if (value < limits::lowest() || value > limits::max())
             throw Exception("Integer Value is Out of Range for IDL Type", PyExc_ValueError);
-        }
+
         if (value == -1 && PyErr_Occurred())
             throw Exception();
 
@@ -141,7 +141,9 @@ public:
             throw Exception("Floating Value is Out of Range for IDL Type", PyExc_ValueError);
         }
 
-        if (value == -1 && PyErr_Occurred()) throw Exception();
+        if (value == -1 && PyErr_Occurred())
+            throw Exception();
+
         cpp = value;
     }
 };

--- a/pyopendds/dev/itl2py/PythonOutput.py
+++ b/pyopendds/dev/itl2py/PythonOutput.py
@@ -24,7 +24,7 @@ class PythonOutput(Output):
         PrimitiveType.Kind.i64: ("int", "0"),
         PrimitiveType.Kind.f32: ("float", "0.0"),
         PrimitiveType.Kind.f64: ("float", "0.0"),
-        PrimitiveType.Kind.c8: ("str", "\\x00"),
+        PrimitiveType.Kind.c8: ("str", "'\\x00'"),
         PrimitiveType.Kind.c16: ("str", "'\\x00'"),
         PrimitiveType.Kind.s8: ("str", "''"),
         PrimitiveType.Kind.s16: ("str", "''"),

--- a/pyopendds/util.py
+++ b/pyopendds/util.py
@@ -1,6 +1,5 @@
-from typing import Union, Tuple, List
+from typing import Union, Tuple
 from datetime import timedelta
-from ctypes import c_ubyte, c_byte
 
 DDS_Duration_t = Tuple[int, int]
 TimeDurationType = Union[timedelta, DDS_Duration_t, int]
@@ -22,43 +21,3 @@ def normalize_time_duration(duration: TimeDurationType):
         raise TypeError("Could not extract time from " + repr(duration))
 
     return seconds, nanoseconds
-
-
-class _BitwiseImpl:
-    value: ...
-
-    def __init__(self, x):
-        ...
-
-    def __int__(self) -> int:
-        ...
-
-    def __or__(self, other):
-        self.value = self.value | other.value
-        return self
-
-    def __and__(self, other):
-        self.value = self.value & other.value
-        return self
-
-    def __xor__(self, other):
-        self.value = self.value ^ other.value
-        return self
-
-    def __ior__(self, other):
-        self.value |= other.value
-        return self
-
-    def __iand__(self, other):
-        self.value &= other.value
-        return self
-
-    def __ixor__(self, other):
-        self.value ^= other.value
-        return self
-
-    def __invert__(self):
-        self.value = ~self.value
-        return self
-
-


### PR DESCRIPTION
As `Byte` and `UByte` were replaced with the native `int` type, the C++ implementation must not try to load their bindings anymore.