### PR TITLE
pyidl doesn't have to prompt anymore

### DIFF
--- a/pyopendds/dev/pyidl/__main__.py
+++ b/pyopendds/dev/pyidl/__main__.py
@@ -31,8 +31,10 @@ def get_base_prefix_compat():
         or sys.prefix
     )
 
+
 def in_virtualenv():
     return get_base_prefix_compat() != sys.prefix
+
 
 def virtualenv_dir():
     return sys.prefix
@@ -179,7 +181,8 @@ def mk_tmp_package_proj(args: argparse.Namespace):
         cwd=args.build_dir,
     )
 
-    """ VERBOSE=1 DFApplication_idl_DIR=../prefix/usr/local/share/cmake/DFApplication_idl/ python setup.py bdist_wheel """
+    """ VERBOSE=1 DFApplication_idl_DIR=../prefix/usr/local/share/cmake/DFApplication_idl/ \
+    python setup.py bdist_wheel """
     # Install the python package py[package_name]
     os.unlink(
         os.path.join(args.build_dir, f"{args.package_name}_idlConfig.cmake")
@@ -261,7 +264,7 @@ def run():
     current_dir = os.getcwd()
 
     # Check if an environment is sourced
-    if not in_virtualenv():
+    if not args.force_install and not in_virtualenv():
         if not prompt(
             "No virtual environment seems to be sourced. Would you like to continue ?"
         ):

--- a/pyopendds/dev/pyidl/__main__.py
+++ b/pyopendds/dev/pyidl/__main__.py
@@ -259,17 +259,21 @@ def run():
     parser.add_argument(
         "--force-install", action="store_true", help="install the generated package"
     )
+    parser.add_argument(
+        "-y", "--yes", action="store_true", help="respond to yes to prompt"
+    )
 
     args = parser.parse_args()
     current_dir = os.getcwd()
 
     # Check if an environment is sourced
     if not args.force_install and not in_virtualenv():
-        if not prompt(
-            "No virtual environment seems to be sourced. Would you like to continue ?"
-        ):
-            print("Aborting...")
-            sys.exit(1)
+        if not args.yes:
+            if not prompt(
+                "No virtual environment seems to be sourced. Would you like to continue ?"
+            ):
+                print("Aborting...")
+                sys.exit(1)
 
     # Initialize include paths or convert directories names into absolute paths
     if not args.include_paths:


### PR DESCRIPTION
Now `force_install` can be taken as yes, so:
- if `force_install`, pyidl won't prompt. ✅
- if not `force_install` and `in_venv`, pydil won't prompt. ✅
- if not `force_install` and not `in_venv`, pyidl will prompt. ⚠️

Actually, as pyidl is not installing the package by default anymore, the prompt is useless if `force_install` is not given.
Nevertheless I'll keep the in_venv prompt logic, in case we improve the semantic with two different options "--install" and "--force-reinstall" which have very different meanings.

---

The yes argument can be provided anyway.
